### PR TITLE
added rock_the_slackbot_send_webhook_message action

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please use [the Issues section of this repo](https://github.com/bamadesigner/roc
 
 ## Send A Simple Slack Message
 
-You can use the following send_webhook_message() function to send a simple message to your Slack account.
+You can use the `rock_the_slackbot_send_webhook_message` action to send a simple message to your Slack account.
 
 **The function accepts the following parameters:**
 
@@ -56,8 +56,8 @@ You can use the following send_webhook_message() function to send a simple messa
 3. $channel - OPTIONAL - the channel you want to send message to. Prefix with # for a specific channel or @ for a specific user. Will use default channel if nothing is passed.
 
 ```
-// Use this function to send a simple message to Slack
-rock_the_slackbot()->send_webhook_message( '564d3c1cdf52d', 'this is a test', '#testchannel' );
+// Use this action to send a simple message to Slack
+do_action( 'rock_the_slackbot_send_webhook_message', '564d3c1cdf52d', 'this is a test', '#testchannel' );
 ```
 
 ## Filters

--- a/plugin.php
+++ b/plugin.php
@@ -87,6 +87,9 @@ class Rock_The_Slackbot {
 		// Runs when the plugin is upgraded
 		add_action( 'upgrader_process_complete', array( $this, 'upgrader_process_complete' ), 1, 2 );
 
+		// Expose the send_webhook_message function via an action
+		add_action( 'rock_the_slackbot_send_webhook_message', array( $this, 'send_webhook_message'), 10, 3 );
+
 	}
 
 	/**


### PR DESCRIPTION
This provides access to the rock_the_slackbot()->send_webhook_message() function via an action rather than having to call the function directly.  This makes it a little safer so if the plugin is deactivated, other plugins using the action instead of the direct function call won't break.
