### PR TITLE
Process slack_response only when not a WP_Error object

### DIFF
--- a/includes/outgoing-webhooks.php
+++ b/includes/outgoing-webhooks.php
@@ -165,8 +165,8 @@ class Rock_The_Slackbot_Outgoing_Webhooks {
 
 			}
 
-			// If there's an error from Slack...
-			if ( isset( $slack_response[ 'response' ] ) && isset( $slack_response[ 'response' ][ 'code' ] ) && '200' != $slack_response[ 'response' ][ 'code' ] ) {
+			// Else if there's an error from Slack...
+			else if ( isset( $slack_response[ 'response' ] ) && isset( $slack_response[ 'response' ][ 'code' ] ) && '200' != $slack_response[ 'response' ][ 'code' ] ) {
 
 				// Set an error
 				$slack_errors->add( 'slack_outgoing_webhook_error', __( 'The payload did not send to Slack.', 'rock-the-slackbot' ) );


### PR DESCRIPTION
In case $slack_response is a WP_Error object, the terms of the second conditional statement are also verified, which causes a fatal error, namely:

```
PHP Fatal error:  Cannot use object of type WP_Error as array in /var/www/project/wp-content/plugins/rock-the-slackbot/includes/outgoing-webhooks.php on line 164
```

Changing to an `else if` statement makes more sense and avoids the crash of the PHP process and losing metadata (custom fields values) while saving a post.
