### PR TITLE
Alert unpublished posts that go to a pending status as "unpublished"

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -1443,6 +1443,9 @@ class Rock_The_Slackbot_Hooks {
 
 			case 'pending':
 				$notification_event = 'post_pending';
+				if ($old_status == 'publish') {
+                    			$notification_event = 'post_unpublished';
+                		}
 				break;
 
 			case 'future':


### PR DESCRIPTION
Having a new post appear as "pending" is a very different situation than a post that is already published and that gets unpublished because the author makes a modification (so it's pending review to be republished). We use the "Event Manager" plugin that has this mechanism and the alert for an updated event (unpublished until approved" is much more urgent than a new event being submitted for review.